### PR TITLE
fix entrypoint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,5 +31,5 @@ setuptools.setup(
     packages=setuptools.find_packages(where="pearson_pdf"),
     install_requires=["requests", "pillow"],
     python_requires=">=3.9",  # TODO: support more versions
-    entry_points={"console_scripts": ["pearson_pdf=pearson_pdf"]},
+    entry_points={"console_scripts": ["pearson_pdf=pearson_pdf:__main__"]},
 )


### PR DESCRIPTION
```
ERROR: For req: pearson-pdf. Invalid script entry point: <ExportEntry pearson_pdf = pearson_pdf:None []> - A callable suffix is required. Cf https://packaging.python.org/specifications/entry-points/#use-for-scripts for more information.
```