### PR TITLE
build: drop support for python 3.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,7 +47,7 @@ jobs:
     strategy:
       matrix:
         os: [macos-latest, ubuntu-latest, windows-latest]
-        python-version: ["3.9", "3.8", "3.7", "3.6"]
+        python-version: ["3.9", "3.8", "3.7"]
     runs-on: ${{ matrix.os }}
     steps:
       - uses: actions/checkout@v2
@@ -75,7 +75,7 @@ jobs:
             ${{ runner.os }}-poetry-${{ matrix.python-version }}-
       - name: Cache dependencies (Windows)
         uses: actions/cache@v2
-        if: startsWith(runner.os, 'Windows') && (matrix.python-version != 3.6)
+        if: startsWith(runner.os, 'Windows')
         with:
           path: "C:\\Users\\runneradmin\\AppData\\Local\\pypoetry\\Cache"
           key: ${{ runner.os }}-poetry-${{ matrix.python-version }}-${{ hashFiles('poetry.lock') }}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -19,7 +19,7 @@ classifiers = [
 exclude = ["tests"]
 
 [tool.poetry.dependencies]
-python = "^3.6.2"
+python = "^3.7"
 requests = "^2.26.0"
 Pillow = "^8.3.2"
 


### PR DESCRIPTION
Closes #61
macos-latest on Actions is transitioning to macos-11, which will also no longer have support for Python 3.6. actions/virtual-environments#4060